### PR TITLE
Cleanup the game even if deleting the peer fails

### DIFF
--- a/deep-sea-stories/packages/backend/src/game/room.ts
+++ b/deep-sea-stories/packages/backend/src/game/room.ts
@@ -207,11 +207,11 @@ export class GameRoom {
 					this.roomId,
 					this.gameSession.agentId,
 				);
-				this.gameSession = null;
 			}
 		} catch (e) {
 			if (!(e instanceof PeerNotFoundException)) throw e;
 		} finally {
+			this.gameSession = null;
 			this.story = undefined;
 
 			this.notifierService.emitNotification(this.roomId, {

--- a/deep-sea-stories/packages/backend/src/game/room.ts
+++ b/deep-sea-stories/packages/backend/src/game/room.ts
@@ -200,28 +200,28 @@ export class GameRoom {
 			this.gameTimeoutId = null;
 		}
 
-		if (this.gameSession) {
-			await this.gameSession.stopGame(wait);
-			try {
+		try {
+			if (this.gameSession) {
+				await this.gameSession.stopGame(wait);
 				await this.fishjamClient.deletePeer(
 					this.roomId,
 					this.gameSession.agentId,
 				);
 				this.gameSession = null;
-			} catch (e) {
-				if (!(e instanceof PeerNotFoundException)) throw e;
 			}
+		} catch (e) {
+			if (!(e instanceof PeerNotFoundException)) throw e;
+		} finally {
+			this.story = undefined;
+
+			this.notifierService.emitNotification(this.roomId, {
+				type: 'gameEnded' as const,
+				timestamp: Date.now(),
+			});
+
+			this.gameStarted = false;
+			console.log(`Stopped game for room ${this.roomId}`);
 		}
-
-		this.story = undefined;
-
-		this.notifierService.emitNotification(this.roomId, {
-			type: 'gameEnded' as const,
-			timestamp: Date.now(),
-		});
-
-		this.gameStarted = false;
-		console.log(`Stopped game for room ${this.roomId}`);
 	}
 
 	private async createFishjamAgent() {

--- a/deep-sea-stories/packages/web/src/components/AgentModeToggle.tsx
+++ b/deep-sea-stories/packages/web/src/components/AgentModeToggle.tsx
@@ -1,9 +1,9 @@
-import { EarOff, Headphones } from 'lucide-react';
+import { Check, CircleX, EarOff, Headphones } from 'lucide-react';
 import { type FC, useEffect, useState } from 'react';
-import { toast } from 'sonner';
 import { useTRPCClient } from '@/contexts/trpc';
 import { useAgentEvents } from '@/hooks/useAgentEvents';
 import { Button } from './ui/button';
+import { toast } from './ui/sonner';
 
 type AgentModeToggleProps = {
 	roomId: string;
@@ -40,10 +40,11 @@ const AgentModeToggle: FC<AgentModeToggleProps> = ({ roomId }) => {
 				muted: !isAiMuted,
 			});
 
-			toast.success(!isAiMuted ? 'Agent deafened' : 'Agent listening');
+			toast(!isAiMuted ? 'Agent deafened' : 'Agent listening', Check);
 		} catch (error) {
-			console.error('Failed to toggle AI mode:', error);
-			toast.error('Failed to toggle mode');
+			console.error(error);
+			const verb = isAiMuted ? 'undeafen' : 'deafen';
+			toast(`Failed to ${verb} agent`, CircleX);
 		} finally {
 			setIsMutating(false);
 		}

--- a/deep-sea-stories/packages/web/src/components/StorySelectionPanel.tsx
+++ b/deep-sea-stories/packages/web/src/components/StorySelectionPanel.tsx
@@ -1,5 +1,5 @@
 import type { StoryData } from '@deep-sea-stories/common';
-import { Check } from 'lucide-react';
+import { Check, X } from 'lucide-react';
 import type { FC } from 'react';
 import { useEffect, useState } from 'react';
 import { useTRPCClient } from '@/contexts/trpc';
@@ -38,7 +38,7 @@ const StorySelectionPanel: FC<StorySelectionPanelProps> = ({
 				setStories(fetchedStories);
 			} catch (error) {
 				console.error('Failed to fetch stories:', error);
-				toast('Failed to load stories', Check);
+				toast('Failed to load stories', X);
 			} finally {
 				setIsLoadingStories(false);
 			}
@@ -63,7 +63,7 @@ const StorySelectionPanel: FC<StorySelectionPanelProps> = ({
 		} catch (error) {
 			const errorMessage =
 				error instanceof Error ? error.message : 'Failed to select story';
-			toast(`Error: ${errorMessage}`, Check);
+			toast(errorMessage, X);
 		} finally {
 			setIsStarting(false);
 		}

--- a/deep-sea-stories/packages/web/src/components/ui/sonner.tsx
+++ b/deep-sea-stories/packages/web/src/components/ui/sonner.tsx
@@ -33,7 +33,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
 			toastOptions={{
 				classNames: {
 					toast:
-						'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+						'group toast group-[.toaster]:text-foreground group-[.toaster]:border-border w-full items-center justify-center flex group-[.toaster]:shadow-lg',
 					description: 'group-[.toast]:text-muted-foreground',
 					actionButton:
 						'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',

--- a/deep-sea-stories/packages/web/src/views/HomeView.tsx
+++ b/deep-sea-stories/packages/web/src/views/HomeView.tsx
@@ -4,6 +4,8 @@ import Footer from '@/components/Footer';
 import TitleBar from '@/components/TitleBar';
 import { Button } from '@/components/ui/button';
 import { useTRPCClient } from '@/contexts/trpc';
+import { toast } from '@/components/ui/sonner';
+import { CircleX } from 'lucide-react';
 
 export default function HomeView() {
 	const navigate = useNavigate();
@@ -16,7 +18,8 @@ export default function HomeView() {
 			const room = await trpcClient.createRoom.mutate();
 			navigate(`/${room.id}`);
 		} catch (error) {
-			console.error('Failed to create room:', error);
+			toast('Failed to create room', CircleX);
+			console.error(error);
 		} finally {
 			setIsLoading(false);
 		}

--- a/deep-sea-stories/packages/web/src/views/JoinView.tsx
+++ b/deep-sea-stories/packages/web/src/views/JoinView.tsx
@@ -4,7 +4,7 @@ import {
 	useInitializeDevices,
 	useMicrophone,
 } from '@fishjam-cloud/react-client';
-import { Camera, Mic, User } from 'lucide-react';
+import { Camera, CircleX, Mic, User } from 'lucide-react';
 import type { FC } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { DeviceSelect } from '@/components/DeviceSelect';
@@ -66,13 +66,16 @@ const JoinView: FC<JoinViewProps> = ({ roomId }) => {
 				peerMetadata: { name },
 			});
 		} catch (error) {
-			if (
-				error instanceof TRPCClientError &&
-				error.data?.code === 'BAD_REQUEST'
-			) {
-				toast(error.message, User);
+			if (!(error instanceof TRPCClientError)) {
+				console.error(error);
+				return;
 			}
-			console.error(error);
+
+			if (error.data?.code === 'BAD_REQUEST') {
+				toast(error.message, User);
+			} else {
+				toast(error.message, CircleX);
+			}
 		}
 	}, [trpcClient, roomId, joinRoom, name]);
 


### PR DESCRIPTION
Closes FCE-2680

The error when changing story only occurred when `this.deletePeer` failed, because of improper cleanup