### PR TITLE
FCE-3216 Update examples to use sandbox api url

### DIFF
--- a/mobile-react-native/blur-example/hooks/useConnectFishjam.ts
+++ b/mobile-react-native/blur-example/hooks/useConnectFishjam.ts
@@ -14,9 +14,7 @@ export const useConnectFishjam = () => {
 
   const { leaveRoom, joinRoom } = useConnection();
   const { getSandboxPeerToken } = useSandbox({
-    configOverride: {
-      sandboxApiUrl: process.env.EXPO_PUBLIC_FISHJAM_URL,
-    },
+    sandboxApiUrl: process.env.EXPO_PUBLIC_SANDBOX_API_URL ?? '',
   });
   const { initializeDevices } = useInitializeDevices();
 

--- a/mobile-react-native/fishjam-chat/app/livestream/screen-sharing.tsx
+++ b/mobile-react-native/fishjam-chat/app/livestream/screen-sharing.tsx
@@ -19,7 +19,9 @@ export default function LivestreamScreenSharingScreen() {
   }>();
 
   const { initializeDevices } = useInitializeDevices();
-  const { getSandboxLivestream } = useSandbox();
+  const { getSandboxLivestream } = useSandbox({
+    sandboxApiUrl: process.env.EXPO_PUBLIC_SANDBOX_API_URL ?? '',
+  });
   const { connect, disconnect, isConnected, error } = useLivestreamStreamer();
   const {
     startStreaming: startScreenCapture,

--- a/mobile-react-native/fishjam-chat/app/livestream/streamer.tsx
+++ b/mobile-react-native/fishjam-chat/app/livestream/streamer.tsx
@@ -20,7 +20,9 @@ export default function LivestreamStreamerScreen() {
     roomName: string;
   }>();
 
-  const { getSandboxLivestream } = useSandbox();
+  const { getSandboxLivestream } = useSandbox({
+    sandboxApiUrl: process.env.EXPO_PUBLIC_SANDBOX_API_URL ?? '',
+  });
 
   const { connect, disconnect, isConnected, error } = useLivestreamStreamer();
 

--- a/mobile-react-native/fishjam-chat/app/livestream/viewer.tsx
+++ b/mobile-react-native/fishjam-chat/app/livestream/viewer.tsx
@@ -16,7 +16,9 @@ export default function LivestreamViewerScreen() {
     roomName: string;
   }>();
 
-  const { getSandboxViewerToken } = useSandbox({});
+  const { getSandboxViewerToken } = useSandbox({
+    sandboxApiUrl: process.env.EXPO_PUBLIC_SANDBOX_API_URL ?? '',
+  });
 
   const { connect, disconnect, stream, isConnected, error } =
     useLivestreamViewer();

--- a/mobile-react-native/fishjam-chat/app/room/preview.tsx
+++ b/mobile-react-native/fishjam-chat/app/room/preview.tsx
@@ -21,7 +21,9 @@ export default function PreviewScreen() {
     userName: string;
   }>();
 
-  const { getSandboxPeerToken } = useSandbox();
+  const { getSandboxPeerToken } = useSandbox({
+    sandboxApiUrl: process.env.EXPO_PUBLIC_SANDBOX_API_URL ?? '',
+  });
 
   const { initializeDevices } = useInitializeDevices();
   const { cameraStream, startCamera, stopCamera, isCameraOn, toggleCamera } =

--- a/mobile-react-native/minimal-react-native/hooks/useConnectFishjam.ts
+++ b/mobile-react-native/minimal-react-native/hooks/useConnectFishjam.ts
@@ -14,9 +14,7 @@ export const useConnectFishjam = () => {
 
   const { leaveRoom, joinRoom } = useConnection();
   const { getSandboxPeerToken } = useSandbox({
-    configOverride: {
-      sandboxApiUrl: process.env.EXPO_PUBLIC_FISHJAM_URL,
-    },
+    sandboxApiUrl: process.env.EXPO_PUBLIC_SANDBOX_API_URL ?? '',
   });
   const { initializeDevices } = useInitializeDevices();
 

--- a/mobile-react-native/text-chat/hooks/useConnectFishjam.ts
+++ b/mobile-react-native/text-chat/hooks/useConnectFishjam.ts
@@ -8,7 +8,9 @@ import type { RootStackParamList } from '../navigation/RootNavigation';
 export const useConnectFishjam = () => {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const { leaveRoom, joinRoom } = useConnection();
-  const { getSandboxPeerToken } = useSandbox();
+  const { getSandboxPeerToken } = useSandbox({
+    sandboxApiUrl: process.env.EXPO_PUBLIC_SANDBOX_API_URL ?? '',
+  });
 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);

--- a/mobile-react-native/video-player/components/FishjamPlayerStreamer.tsx
+++ b/mobile-react-native/video-player/components/FishjamPlayerStreamer.tsx
@@ -10,7 +10,9 @@ import { useEffect } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 export const FishjamPlayerStreamer = ({ roomName }: { roomName: string }) => {
-  const { getSandboxLivestream } = useSandbox();
+  const { getSandboxLivestream } = useSandbox({
+    sandboxApiUrl: process.env.EXPO_PUBLIC_SANDBOX_API_URL ?? '',
+  });
 
   const { toggleCamera, stopCamera, startCamera, isCameraOn, cameraStream } =
     useCamera();

--- a/mobile-react-native/video-player/components/FishjamPlayerViewer.tsx
+++ b/mobile-react-native/video-player/components/FishjamPlayerViewer.tsx
@@ -7,7 +7,9 @@ import { useEffect } from 'react';
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
 
 export const FishjamPlayerViewer = ({ roomName }: { roomName: string }) => {
-  const { getSandboxViewerToken } = useSandbox();
+  const { getSandboxViewerToken } = useSandbox({
+    sandboxApiUrl: process.env.EXPO_PUBLIC_SANDBOX_API_URL ?? '',
+  });
   const { connect, disconnect, stream } = useLivestreamViewer();
 
   useEffect(() => {

--- a/web-react/audio-only/src/JoinRoomForm.tsx
+++ b/web-react/audio-only/src/JoinRoomForm.tsx
@@ -2,6 +2,11 @@ import { useConnection, useSandbox } from "@fishjam-cloud/react-client";
 import type { FC } from "react";
 import { useCallback } from "react";
 
+const SANDBOX_API_URL =
+  new URLSearchParams(window.location.search).get("sandboxApiUrl") ??
+  import.meta.env.VITE_SANDBOX_API_URL ??
+  "";
+
 export type RoomManagerParams = {
   roomName: string;
   peerName: string;
@@ -13,7 +18,9 @@ type JoinRoomFormProps = {
 
 export const JoinRoomForm: FC<JoinRoomFormProps> = ({ onJoinedRoom }) => {
   const { joinRoom } = useConnection();
-  const { getSandboxPeerToken } = useSandbox();
+  const { getSandboxPeerToken } = useSandbox({
+    sandboxApiUrl: SANDBOX_API_URL,
+  });
 
   const onJoinRoom = useCallback(
     async (params: RoomManagerParams) => {

--- a/web-react/fishjam-chat/src/components/JoinRoomCard.tsx
+++ b/web-react/fishjam-chat/src/components/JoinRoomCard.tsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
-import { DEFAULT_FISHJAM_ID } from "@/lib/consts";
+import { DEFAULT_FISHJAM_ID, SANDBOX_API_URL } from "@/lib/consts";
 import { getPersistedFormValues, persistFormValues } from "@/lib/utils";
 import type { RoomForm } from "@/types";
 
@@ -65,7 +65,9 @@ export const JoinRoomCard: FC<Props> = ({ onFishjamIdChange, ...props }) => {
     onFishjamIdChange(formFishjamId);
   }, [formFishjamId, onFishjamIdChange]);
 
-  const { getSandboxPeerToken } = useSandbox();
+  const { getSandboxPeerToken } = useSandbox({
+    sandboxApiUrl: SANDBOX_API_URL,
+  });
 
   const initializeAndReport = useCallback(async () => {
     const { errors } = await initializeDevices({

--- a/web-react/fishjam-chat/src/lib/consts.ts
+++ b/web-react/fishjam-chat/src/lib/consts.ts
@@ -1,3 +1,8 @@
 export const DEFAULT_FISHJAM_ID =
   new URLSearchParams(window.location.search).get("fishjamId") ??
   import.meta.env.VITE_FISHJAM_ID;
+
+export const SANDBOX_API_URL =
+  new URLSearchParams(window.location.search).get("sandboxApiUrl") ??
+  import.meta.env.VITE_SANDBOX_API_URL ??
+  "";

--- a/web-react/livestreaming/src/components/LivestreamStreamer.tsx
+++ b/web-react/livestreaming/src/components/LivestreamStreamer.tsx
@@ -11,6 +11,8 @@ import type { FC } from "react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 
+import { SANDBOX_API_URL } from "@/lib/consts";
+
 import { Alert, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
 import {
@@ -53,7 +55,9 @@ const LivestreamStreamer: FC<LivestreamStreamerProps> = ({
 
   const [isConnecting, setIsConnecting] = useState(false);
 
-  const { getSandboxLivestream } = useSandbox();
+  const { getSandboxLivestream } = useSandbox({
+    sandboxApiUrl: SANDBOX_API_URL,
+  });
   const { connect, disconnect, isConnected, error } = useLivestreamStreamer();
 
   const initializeAndReport = useCallback(async () => {

--- a/web-react/livestreaming/src/components/LivestreamViewer.tsx
+++ b/web-react/livestreaming/src/components/LivestreamViewer.tsx
@@ -4,6 +4,8 @@ import type { FC } from "react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
+import { SANDBOX_API_URL } from "@/lib/consts";
+
 import { Alert, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
 import {
@@ -26,7 +28,9 @@ const LivestreamViewer: FC<LivestreamViewerProps> = ({
   roomName: streamerRoomName,
 }) => {
   const { connect, disconnect, stream, error } = useLivestreamViewer();
-  const { getSandboxViewerToken } = useSandbox();
+  const { getSandboxViewerToken } = useSandbox({
+    sandboxApiUrl: SANDBOX_API_URL,
+  });
   const [nameOverridden, setNameOverridden] = useState(false);
   const [roomName, setRoomName] = useState(streamerRoomName);
 

--- a/web-react/livestreaming/src/lib/consts.ts
+++ b/web-react/livestreaming/src/lib/consts.ts
@@ -1,3 +1,8 @@
 export const DEFAULT_FISHJAM_ID =
   new URLSearchParams(window.location.search).get("fishjamId") ??
   import.meta.env.VITE_FISHJAM_ID;
+
+export const SANDBOX_API_URL =
+  new URLSearchParams(window.location.search).get("sandboxApiUrl") ??
+  import.meta.env.VITE_SANDBOX_API_URL ??
+  "";

--- a/web-react/text-chat/src/App.tsx
+++ b/web-react/text-chat/src/App.tsx
@@ -5,6 +5,11 @@ import {
 } from "@fishjam-cloud/react-client";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+const SANDBOX_API_URL =
+  new URLSearchParams(window.location.search).get("sandboxApiUrl") ??
+  import.meta.env.VITE_SANDBOX_API_URL ??
+  "";
+
 type ChatMessage = {
   timestamp: number;
   sender: string;
@@ -20,7 +25,9 @@ export const App = () => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const { joinRoom, leaveRoom, peerStatus } = useConnection();
-  const { getSandboxPeerToken } = useSandbox();
+  const { getSandboxPeerToken } = useSandbox({
+    sandboxApiUrl: SANDBOX_API_URL,
+  });
   const {
     publishData,
     subscribeData,


### PR DESCRIPTION
- Pass `sandboxApiUrl` to `useSandbox` across web-react and mobile-react-native examples, matching the new flat-prop API: `useSandbox({ sandboxApiUrl })`.
- Web examples read the URL from `?sandboxApiUrl=` query param first, then `VITE_SANDBOX_API_URL`, then empty string — mirroring the existing `DEFAULT_FISHJAM_ID` pattern.
- Mobile examples read from `EXPO_PUBLIC_SANDBOX_API_URL`.
- Replaced the old `configOverride: { sandboxApiUrl: EXPO_PUBLIC_FISHJAM_URL }` shape in `blur-example` and `minimal-react-native` with the new flat shape + new env var name.